### PR TITLE
Improve error messages and checks

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -17,6 +17,7 @@
 #include "convert.h"
 #include "record.h"
 #include "avroenum.h"
+#include <avro/schema.h>
 
 static PyObject *avro_types_type = NULL;
 
@@ -496,6 +497,9 @@ python_to_record(ConvertInfo *info, PyObject *pyobj, avro_value_t *dest)
         rval = python_to_avro(info, pyval, &field_value);
         Py_DECREF(pyval);
         if (rval) {
+            avro_prefix_error("when writing to %s.%s, ",
+                    avro_schema_name(avro_value_get_schema(dest)),
+                    field_name);
             return rval;
         }
     }

--- a/src/filewriter.c
+++ b/src/filewriter.c
@@ -48,6 +48,7 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     file = PyFile_AsFile(pyfile);
 
     if (file == NULL) {
+        PyErr_Format(PyExc_IOError, "Error accessing file (PyFile_AsFile failed)");
         return -1;
     }
 

--- a/src/filewriter.c
+++ b/src/filewriter.c
@@ -48,7 +48,7 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     file = PyFile_AsFile(pyfile);
 
     if (file == NULL) {
-        PyErr_Format(PyExc_IOError, "Error accessing file (PyFile_AsFile failed)");
+        PyErr_Format(PyExc_TypeError, "Error accessing file object.  Is it a file or file-like object?");
         return -1;
     }
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -99,3 +99,11 @@ def test_write_read_empty():
     assert len(read_recs) == 0
 
     shutil.rmtree(dirname)
+
+def test_bad_file_argument():
+    try:
+        with tempfile.NamedTemporaryFile() as fp:
+            writer = pyavroc.AvroFileWriter(fp, '["null", "int"]')
+            writer.close()
+    except TypeError:
+        pass


### PR DESCRIPTION
This pull request introduces checks on the return values from the Python-C type conversion functions to verify whether they were successful.  It also improves some of the error messages returned by the Python to Avro conversion to help the user find discrepancies between the schema and the input object.