### PR TITLE
Type coercion

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -443,11 +443,18 @@ get_branch_index(ConvertInfo *info, PyObject *pyobj, avro_schema_t schema)
     branch_schema = avro_schema_union_branch_by_name(schema,
                                                      &branch_index,
                                                      typename);
-    /* maybe Python "float" vs avro "double" */
-    if (branch_schema == NULL && PyFloat_CheckExact(pyobj)) {
-        branch_schema = avro_schema_union_branch_by_name(schema,
-                                                         &branch_index,
-                                                         "double");
+    if (branch_schema == NULL) {
+        /* maybe Python "float" vs avro "double" */
+        if (PyFloat_CheckExact(pyobj)) {
+            branch_schema = avro_schema_union_branch_by_name(schema,
+                                                             &branch_index,
+                                                             "double");
+        }
+        else if (PyInt_CheckExact(pyobj)) { /* may also be Python int vs long */
+            branch_schema = avro_schema_union_branch_by_name(schema,
+                                                             &branch_index,
+                                                             "long");
+        }
     }
 
     if (branch_schema == NULL) {

--- a/src/convert.c
+++ b/src/convert.c
@@ -457,6 +457,13 @@ get_branch_index(ConvertInfo *info, PyObject *pyobj, avro_schema_t schema)
         }
     }
 
+    /* As a last resort, check to see if 'boolean' is in the union. Then we should try
+     * interpreting the value as one. */
+    if (branch_schema == NULL) {
+        branch_schema = avro_schema_union_branch_by_name(schema,
+                                                         &branch_index,
+                                                         "boolean");
+    }
     if (branch_schema == NULL) {
         return -1;  /* fail */
     }

--- a/src/convert.c
+++ b/src/convert.c
@@ -465,6 +465,7 @@ get_branch_index(ConvertInfo *info, PyObject *pyobj, avro_schema_t schema)
                                                          "boolean");
     }
     if (branch_schema == NULL) {
+        avro_set_error("no type in union suitable for type %s.", typename);
         return -1;  /* fail */
     }
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -99,3 +99,24 @@ def test_write_read_empty():
     assert len(read_recs) == 0
 
     shutil.rmtree(dirname)
+
+def test_coerce_int_long_in_unions():
+    schema = ''' [ "null", "long"] '''
+
+    with open('/dev/null', 'w') as fp:
+        writer = pyavroc.AvroFileWriter(fp, schema)
+        writer.write(33) # an integer.  Should be coerced to long without an error
+        writer.close()
+
+def test_coerce_int_long():
+    schema = '''{
+        "type": "record",
+        "name": "Rec",
+        "fields": [ {"name": "attr1", "type": "long"} ]
+        }'''
+    av_types = pyavroc.create_types(schema)
+    rec = av_types.Rec(attr1=33) # an integer.  Should be coerced to long without an error
+    with open('/dev/null', 'w') as fp:
+        writer = pyavroc.AvroFileWriter(fp, schema)
+        writer.write(rec)
+        writer.close()


### PR DESCRIPTION
When writing, automatically "upgrade" value types when possible.

`float` -> `double was already implemented.

This pull request adds:

* `int` -> `long`
* `PyObject` -> `boolean`