### PR TITLE
read enum value as string

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -136,15 +136,11 @@ static PyObject *
 enum_to_python(ConvertInfo *info, avro_value_t *value)
 {
     int  val;
+    avro_schema_t schema;
 
     avro_value_get_enum(value, &val);
-
-    /*
-     * avro_schema_t  schema = avro_value_get_schema(value);
-     * symbol_name = avro_schema_enum_get(schema, val);
-     */
-
-    return PyInt_FromLong(val);
+    schema = avro_value_get_schema(value);
+    return PyString_FromString(avro_schema_enum_get(schema, val));
 }
 
 static PyObject *

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import json
 from cStringIO import StringIO
 
 import avro.schema
@@ -82,3 +82,16 @@ def test_big():
         {'name': long_str, 'office': long_str}
     )
     deserializer.deserialize(long_rec_bytes)
+
+
+def test_enum():
+    schema = '''{
+    "type": "enum",
+    "name": "suits",
+    "symbols": ["CLUBS", "DIAMONDS", "HEARTS", "SPADES"]
+    }'''
+    symbols = json.loads(schema)['symbols']
+    serializer = Serializer(schema)
+    deserializer = pyavroc.AvroDeserializer(schema)
+    for s in symbols:
+        assert deserializer.deserialize(serializer.serialize(s)) == s


### PR DESCRIPTION
This PR changes enum value reading so that the symbol string is returned rather than its index, consistently with the original API.