### PR TITLE
Allow unicode map keys

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -540,7 +540,9 @@ validate(PyObject *pyobj, avro_schema_t schema) {
             Py_ssize_t pos = 0;
             if (!PyDict_Check(pyobj)) return -1;
             while (PyDict_Next(pyobj, &pos, &key, &value))
-                if (!PyString_Check(key) || validate(value, subschema) < 0)
+                if (!(PyString_Check(key) || PyUnicode_Check(key)))
+                    return -1;
+                if (validate(value, subschema) < 0)
                     return -1;
             return 0;
         }

--- a/src/convert.c
+++ b/src/convert.c
@@ -539,11 +539,12 @@ validate(PyObject *pyobj, avro_schema_t schema) {
             PyObject *key, *value;
             Py_ssize_t pos = 0;
             if (!PyDict_Check(pyobj)) return -1;
-            while (PyDict_Next(pyobj, &pos, &key, &value))
+            while (PyDict_Next(pyobj, &pos, &key, &value)) {
                 if (!(PyString_Check(key) || PyUnicode_Check(key)))
                     return -1;
                 if (validate(value, subschema) < 0)
                     return -1;
+            }
             return 0;
         }
     case AVRO_UNION:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -82,3 +82,15 @@ def test_serialize_union():
     deserializer = Deserializer(schema)
     for datum in "foo", u"foo", None:
         assert deserializer.deserialize(serializer.serialize(datum)) == datum
+
+
+def test_unicode_map_keys():
+    schema = """\
+    {"type": "record",
+    "name": "foo",
+    "fields": [{"name": "bar",
+                "type": ["null", {"type": "map", "values": "string"}]}]}
+    """
+    serializer = pyavroc.AvroSerializer(schema)
+    rec_bytes = serializer.serialize({"bar": {"k": "v"}})
+    assert serializer.serialize({"bar": {u"k": "v"}}) == rec_bytes

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -32,7 +32,7 @@ TEST_CASES = (
     ('{"type": "enum", "name": "Test", "symbols": ["A", "B"]}', 'A', 0),
     ('{"type": "enum", "name": "Test", "symbols": ["A", "B"]}', 'B', 1),
     ('{"type": "array", "items": "long"}', [1, 3, 2], 0),
-    ('{"type": "map", "values": "long"}', {'a': 1, 'b': 3, 'c': 2}, 0),
+    ('{"type": "map", "values": "long"}', {'a': 1, 'b': 3, u'c': 2}, 0),
     ('["string", "null", "long"]', 'spam', 0),
     ('["string", "null", "long"]', None, 1),
     ('["string", "null", "long"]', 42L, 2),


### PR DESCRIPTION
This PR changes record validation to allow unicode keys in maps. With these changes, map keys can be either strings or unicodes, as in the official Python API.