### PR TITLE
Added support to utf-8 encoded unicode

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -706,26 +706,25 @@ python_to_avro(ConvertInfo *info, PyObject *pyobj, avro_value_t *dest)
     case AVRO_STRING:
         {
             char *buf;
-            int freeutf8 = 0;
             int retval;
             Py_ssize_t len;
             PyObject *aux;
 
             if (PyUnicode_Check(pyobj)) {
                 aux = PyUnicode_AsUTF8String(pyobj);
-                freeutf8 = 1;
             }
             else {
                 aux = pyobj;
+                Py_INCREF(aux);
             }
 
             if (PyString_AsStringAndSize(aux, &buf, &len) < 0) {
                 return set_type_error(EINVAL, pyobj);
             }
             retval = set_avro_error(avro_value_set_string_len(dest, buf, len + 1));
-            if (freeutf8) {
-                Py_DECREF(aux);
-            }
+
+            Py_DECREF(aux);
+
             return retval;
         }
     case AVRO_ARRAY:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Copyright 2015 CRS4
 #
@@ -94,3 +95,17 @@ def test_unicode_map_keys():
     serializer = pyavroc.AvroSerializer(schema)
     rec_bytes = serializer.serialize({"bar": {"k": "v"}})
     assert serializer.serialize({"bar": {u"k": "v"}}) == rec_bytes
+
+
+def test_serialize_utf8_string():
+    schema = '["string"]'
+    serializer = pyavroc.AvroSerializer(schema)
+    deserializer = Deserializer(schema)
+
+    datum = "barà"
+    rec_bytes = serializer.serialize(datum)
+    assert deserializer.deserialize(rec_bytes) == unicode(datum, "utf-8")
+
+    datum = u"barà"
+    rec_bytes = serializer.serialize(datum)
+    assert deserializer.deserialize(rec_bytes) == datum


### PR DESCRIPTION
I fixed a little bug that caused an error when serializing a unicode object with utf-8 characters.

Consider the following code:
```python
schema = '["string"]'
serializer = pyavroc.AvroSerializer(schema)
serializer.serialize(u"barà")
```
Before the correction it would have raised a `TypeError: function takes exactly 5 arguments (1 given)`. It failed because `PyString_AsStringAndSize` returned -1. 
Now `unicode` objects are converted in UTF-8 strings before getting serialized. 