### PR TITLE
Add blocksize and compression kwargs for writer

### DIFF
--- a/src/filewriter.c
+++ b/src/filewriter.c
@@ -31,14 +31,15 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     PyObject *schema_json_bytes;
     FILE *file;
     char *codec = "null";
+    int block_size = PYAVROC_BLOCK_SIZE;
 
     self->pyfile = NULL;
     self->flags = 0;
     self->iface = NULL;
 
-    static char *kwlist[] = { "pyfile", "schema_json", "codec" };
+    static char *kwlist[] = { "pyfile", "schema_json", "codec", "block_size", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|s", kwlist, &pyfile, &schema_json, &codec)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|si", kwlist, &pyfile, &schema_json, &codec, &block_size)) {
         return -1;
     }
 
@@ -63,7 +64,7 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     self->pyfile = pyfile;
     Py_INCREF(pyfile);
 
-    if (avro_file_writer_create_with_codec_fp(file, "pyfile", 0, self->schema, &self->writer, codec, PYAVROC_BLOCK_SIZE)) {
+    if (avro_file_writer_create_with_codec_fp(file, "pyfile", 0, self->schema, &self->writer, codec, block_size)) {
         PyErr_Format(PyExc_IOError, "Error opening file: %s", avro_strerror());
         return -1;
     }

--- a/src/filewriter.c
+++ b/src/filewriter.c
@@ -30,12 +30,15 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     PyObject *schema_json;
     PyObject *schema_json_bytes;
     FILE *file;
+    char *codec = "null";
 
     self->pyfile = NULL;
     self->flags = 0;
     self->iface = NULL;
 
-    if (!PyArg_ParseTuple(args, "OO", &pyfile, &schema_json)) {
+    static char *kwlist[] = { "pyfile", "schema_json", "codec" };
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|s", kwlist, &pyfile, &schema_json, &codec)) {
         return -1;
     }
 
@@ -60,7 +63,7 @@ AvroFileWriter_init(AvroFileWriter *self, PyObject *args, PyObject *kwds)
     self->pyfile = pyfile;
     Py_INCREF(pyfile);
 
-    if (avro_file_writer_create_with_codec_fp(file, "pyfile", 0, self->schema, &self->writer, "null", PYAVROC_BLOCK_SIZE)) {
+    if (avro_file_writer_create_with_codec_fp(file, "pyfile", 0, self->schema, &self->writer, codec, PYAVROC_BLOCK_SIZE)) {
         PyErr_Format(PyExc_IOError, "Error opening file: %s", avro_strerror());
         return -1;
     }


### PR DESCRIPTION
This enables setting the Avro block size and the compression when creating the file writer.