### PR TITLE
Add validation for array and map writing

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -401,6 +401,11 @@ python_to_array(ConvertInfo *info, PyObject *pyobj, avro_value_t *dest)
     Py_ssize_t i;
     Py_ssize_t element_count;
 
+    if (!PyList_Check(pyobj)) {
+        PyErr_Format(PyExc_TypeError, "expected list, %s found", pyobj->ob_type->tp_name);
+        return -1;
+    }
+
     element_count = PyObject_Length(pyobj);
 
     if (element_count < 0) {
@@ -431,6 +436,11 @@ python_to_map(ConvertInfo *info, PyObject *pyobj, avro_value_t *dest)
     size_t element_count;
     PyObject *keys;
     PyObject *vals;
+
+    if (!PyMapping_Check(pyobj)) {
+        PyErr_Format(PyExc_TypeError, "expected dict-like object, %s found", pyobj->ob_type->tp_name);
+        return -1;
+    }
 
     element_count = PyMapping_Length(pyobj);
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -82,7 +82,11 @@ def test_write_wrong_value():
     schema = '''[{"name": "Rec1", "type": "record",
 "fields": [ {"name": "attr1", "type": "int"} ] },
 {"name": "Rec2", "type": "record",
-"fields": [ {"name": "attr2", "type": "string"} ]}
+"fields": [ {"name": "attr2", "type": "string"} ] },
+{"name": "Rec3", "type": "record",
+"fields": [ {"name": "attr3", "type": {"type": "map", "values": "int"}} ] },
+{"name": "Rec4", "type": "record",
+"fields": [ {"name": "attr4", "type": {"type": "array", "items": "int"}} ] }
 ]'''
 
     dirname = tempfile.mkdtemp()
@@ -114,6 +118,27 @@ def test_write_wrong_value():
                      " expected.*Unicode.*, int found"
 
     assert re.search(expected_error, str(excinfo.value))
+
+    with pytest.raises(TypeError) as excinfo:
+        with open(filename, 'w') as fp:
+            writer = pyavroc.AvroFileWriter(fp, schema)
+            writer.write(avtypes.Rec3(attr3=123))
+            writer.close()
+
+    expected_error = "when writing to Rec3.attr3, expected dict-like object, " \
+                     "int found"
+
+    assert expected_error in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        with open(filename, 'w') as fp:
+            writer = pyavroc.AvroFileWriter(fp, schema)
+            writer.write(avtypes.Rec4(attr4=123))
+            writer.close()
+
+    expected_error = "when writing to Rec4.attr4, expected list, int found"
+
+    assert expected_error in str(excinfo.value)
 
     shutil.rmtree(dirname)
 


### PR DESCRIPTION
This checks object types for array and map-type fields so that we have proper errors set with clear messages.

In particular this was an issue for writing maps, where an incorrect value going into a map-type field was leading to a segfault.