### PR TITLE
Improve travis pandoc install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+cache:
+  directories:
+    - pandoc_download
 language: python
 python:
   - "2.6"
@@ -12,13 +15,8 @@ addons:
       - jq
 before_install:
   - uname -a
-  - lsb_release -a
-install:
-  - for TRY in $(seq 5); do PANDOC_META=$(curl --retry 5 https://api.github.com/repos/jgm/pandoc/releases/latest); [ -z "$PANDOC_META" ] || break; sleep 10; done; [ -n "$PANDOC_META" ] || exit 1
-  - PANDOC_URL=$(echo "$PANDOC_META" | jq -r '.assets[] | select(.name|contains(".deb")) | .browser_download_url')
-  - curl -Lo pandoc.deb $PANDOC_URL
-  - dpkg-deb -x pandoc.deb pandoc
-  - export PATH=$(readlink -f pandoc/usr/bin):$PATH
+  - .travis/install_pandoc.sh
+  - export PATH=$TRAVIS_BUILD_DIR/pandoc/usr/bin:$PATH
   - pandoc --version
   - pip install pytest>=2.7.3 --upgrade
 script:

--- a/.travis/install_pandoc.sh
+++ b/.travis/install_pandoc.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Copyright 2017 Ben Walsh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ux
+
+set | grep '^TRAVIS' >&2
+
+SUBDIR=pandoc_download
+
+cd $TRAVIS_BUILD_DIR
+mkdir -p $SUBDIR
+
+for TRY in $(seq 10)
+do
+    curl --retry 5 https://api.github.com/repos/jgm/pandoc/releases/latest >$SUBDIR/meta.json
+
+    PANDOC_URL=$(jq -r '.assets[] | select(.name|contains(".deb")) | .browser_download_url' <$SUBDIR/meta.json)
+
+    case "$PANDOC_URL" in
+        http*)
+            curl -Lo $SUBDIR/pandoc.deb $PANDOC_URL
+            ;;
+        *)
+            cat $SUBDIR/meta.json >&2
+            ;;
+    esac
+
+    if [ -f $SUBDIR/pandoc.deb ]
+    then
+        dpkg-deb -x $SUBDIR/pandoc.deb pandoc
+        exit 0
+    fi
+
+    [ "$TRAVIS_BRANCH" != 'master' ] && [ -z "${TRAVIS_TAG:-}" ] && exit 0
+
+    sleep 60
+done
+
+exit 1


### PR DESCRIPTION
Most of the builds are failing on Travis-ci just because it can't download the pandoc tool. But it only needs pandoc to generate a bit of doc; it shouldn't keep failing if it can't download it.
